### PR TITLE
fix: allow modern moduleResolution in project tsconfig

### DIFF
--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -116,6 +116,7 @@ async function registerTsNode(): Promise<Service> {
     return tsNode.register({
       compilerOptions: {
         module: 'CommonJS',
+        moduleResolution: 'Node',
       },
       moduleTypes: {
         '**': 'cjs',

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -116,7 +116,7 @@ async function registerTsNode(): Promise<Service> {
     return tsNode.register({
       compilerOptions: {
         module: 'CommonJS',
-        moduleResolution: 'Node',
+        moduleResolution: 'Node10',
       },
       moduleTypes: {
         '**': 'cjs',


### PR DESCRIPTION
This small change fixes an issue that makes using Jest impossible inside a TypeScript project configured with NodeNext, Node16 or Bundler moduleResolution setting. 

The default behaviour of ts-node is to read the default tsconfig.json file from the project.
With a hardcoded option of "module: CommonJs" that was used to read the jest.config.ts file, the TypeScript compiler will throw an error, because the modern moduleResolution options are not compatible with
the hardcoded module value.

The only way to use Jest in such a repo is to change the jest.config.ts file into a JS one (or pass the options in a different way), so that the code responsible of instantiating ts-node is not invoked.

This commit fixes the issue by providing a missing complementary option, moduleResolution: Node, which will work perfectly with module: CommonJs and will not be overridden by any project-specific value in tsconfig.json.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
